### PR TITLE
Add repeated encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ understand the API.
 ## Supported:
 
 - Varint (bool/uint32/uint64/sint32/sint64)
-- Repeated: Just append a field multiple times
+- Repeated (bool/uint32/uint64/string/bytes)
 - Nested: Just append an `Anybuf` instance
 
 ## Non supported
@@ -34,9 +34,7 @@ let data = Anybuf::new()
     .append_string(2, "hello")  // field number 2 gets a string
     .append_bytes(3, b"hello")  // field number 3 gets bytes
     .append_message(4, &Anybuf::new().append_bool(3, true)) // field 4 gets a message
-    .append_uint64(5, 23)       // field number 5 is a repeated uint64
-    .append_uint64(5, 56)
-    .append_uint64(5, 192)
+    .append_repeated_uint64(5, &[23, 56, 192])              // field number 5 is a repeated uint64
     .into_vec();                // done
 
 // data is now a serialized protobuf doocument

--- a/README.md
+++ b/README.md
@@ -10,19 +10,23 @@ understand the API.
 
 ## Non goals
 
-- Decoding
+- ~~Decoding~~ (Upcoming in <https://github.com/noislabs/anybuf/pull/2>)
 - protobuf 2 things
 - Field sorting
+- Groups support (deprecated, see <https://protobuf.dev/programming-guides/proto2/#groups>)
 
 ## Supported:
 
-- Varint (bool/uint32/uint64/sint32/sint64)
+- Varint fields (bool/uint32/uint64/sint32/sint64)
+- Variable length fields (string/bytes)
 - Repeated (bool/uint32/uint64/string/bytes)
 - Nested: Just append an `Anybuf` instance
 
 ## Non supported
 
 - Fixed length types
+- Packed encoding for repeated fields
+- int32/int64
 
 ## How to use it
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,22 @@
 //! A minimal (like seriously), zero dependency protobuf encoder.
 //!
+//! ## Non goals
+//! - ~~Decoding~~ (Upcoming in <https://github.com/noislabs/anybuf/pull/2>)
+//! - protobuf 2 things
+//! - Field sorting
+//! - Groups support (deprecated, see <https://protobuf.dev/programming-guides/proto2/#groups>)
+//!
 //! Supported:
-//! - Varint (bool/uint32/uint64/sint32/sint64)
+//! - Varint fields (bool/uint32/uint64/sint32/sint64)
+//! - Variable length fields (string/bytes)
 //! - Repeated (bool/uint32/uint64/string/bytes)
 //! - Nested: Just append an `Anybuf` instance
 //!
 //! Non supported:
 //!
 //! - Fixed length types
-//! - Field sorting
+//! - Packed encoding for repeated fields
+//! - int32/int64
 
 mod varint;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,6 +173,7 @@ impl Anybuf {
     /// Appends a repeated field of type string.
     ///
     /// Use this instead of multiple [`Anybuf::append_string`] to ensure "" values are not lost.
+    ///
     /// ## Example
     ///
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,7 +139,7 @@ impl Anybuf {
 
     /// Appends a repeated field of type uint32.
     ///
-    /// Use this instead of multiple `append_uint32` to ensure 0 values are not lost.
+    /// Use this instead of multiple [`Anybuf::append_uint32`] to ensure 0 values are not lost.
     pub fn append_repeated_uint32(mut self, field_number: u32, data: &[u32]) -> Self {
         for value in data {
             self.append_tag(field_number, WireType::Varint);
@@ -150,7 +150,7 @@ impl Anybuf {
 
     /// Appends a repeated field of type uint64.
     ///
-    /// Use this instead of multiple `append_uint64` to ensure 0 values are not lost.
+    /// Use this instead of multiple [`Anybuf::append_uint64`] to ensure 0 values are not lost.
     pub fn append_repeated_uint64(mut self, field_number: u32, data: &[u64]) -> Self {
         for value in data {
             self.append_tag(field_number, WireType::Varint);
@@ -161,7 +161,7 @@ impl Anybuf {
 
     /// Appends a repeated field of type bool.
     ///
-    /// Use this instead of multiple `append_bool` to ensure false values are not lost.
+    /// Use this instead of multiple [`Anybuf::append_bool`] to ensure false values are not lost.
     pub fn append_repeated_bool(mut self, field_number: u32, data: &[bool]) -> Self {
         for value in data {
             self.append_tag(field_number, WireType::Varint);
@@ -172,7 +172,18 @@ impl Anybuf {
 
     /// Appends a repeated field of type string.
     ///
-    /// Use this instead of multiple `append_string` to ensure "" values are not lost.
+    /// Use this instead of multiple [`Anybuf::append_string`] to ensure "" values are not lost.
+    /// ## Example
+    ///
+    /// ```
+    /// # use anybuf::Anybuf;
+    /// let name = "Bono".to_string();
+    ///
+    /// // Three string fields with field number 4
+    /// let serialized = Anybuf::new()
+    ///     .append_repeated_string(4, &["", "Caro", &name])
+    ///     .into_vec();
+    /// ```
     pub fn append_repeated_string(mut self, field_number: u32, data: &[&str]) -> Self {
         for value in data {
             self.append_tag(field_number, WireType::Len);
@@ -184,7 +195,19 @@ impl Anybuf {
 
     /// Appends a repeated field of type bytes.
     ///
-    /// Use this instead of multiple `append_string` to ensure empty values are not lost.
+    /// Use this instead of multiple [`Anybuf::append_bytes`] to ensure empty values are not lost.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// # use anybuf::Anybuf;
+    /// let blob = vec![4u8; 75];
+    ///
+    /// // Three bytes fields with field number 5
+    /// let serialized = Anybuf::new()
+    ///     .append_repeated_bytes(5, &[b"", b"abcd", &blob])
+    ///     .into_vec();
+    /// ```
     pub fn append_repeated_bytes(mut self, field_number: u32, data: &[&[u8]]) -> Self {
         for value in data {
             // tag
@@ -197,11 +220,17 @@ impl Anybuf {
         self
     }
 
+    /// Returns the protobuf bytes of the instance.
+    ///
+    /// The data is the same as [`Anybuf::into_vec`] but does not consume the instance.
     pub fn as_bytes(&self) -> &[u8] {
         &self.output
     }
 
-    /// Takes the instance and returns the protobuf bytes
+    /// Takes the instance and returns the protobuf bytes.
+    ///
+    /// The data is the same as [`Anybuf::as_bytes`] but consumes the instance in order to
+    /// return an owned vector without cloning the data.
     pub fn into_vec(self) -> Vec<u8> {
         self.output
     }

--- a/tests.proto
+++ b/tests.proto
@@ -11,3 +11,16 @@ message Room {
   sint32 altitude = 4;
   sint64 temperature = 5;
 }
+
+message Collection {
+  string id                       =  1;
+  repeated uint32 numbers_uint32  =  2 [packed = false];
+  repeated uint64 numbers_uint64  =  3 [packed = false];
+  repeated sint32 numbers_sint32  =  4 [packed = false];
+  repeated sint64 numbers_sint64  =  5 [packed = false];
+  repeated int32 numbers_int32    =  6 [packed = false];
+  repeated int64 numbers_int64    =  7 [packed = false];
+  repeated bool booleans          =  8 [packed = false];
+  repeated string strings         =  9 [packed = false];
+  repeated bytes bytess           = 10 [packed = false];
+}


### PR DESCRIPTION
Turns out that using `append_*` multiple times is not a good idea for the repeated implementation as this skips empty/default values such as 0 or "". Instead we need explocit repeated encodings.

- [x] append_repeated_bool
- [x] append_repeated_uint32
- [x] append_repeated_uint64
- [x] append_repeated_sint32
- [x] append_repeated_sint64
- [x] append_repeated_string
- [x] append_repeated_bytes
- [ ] append_repeated_message